### PR TITLE
Fix Terraform state bucket name

### DIFF
--- a/scripts/deploy/bootstrap-site-state.ts
+++ b/scripts/deploy/bootstrap-site-state.ts
@@ -28,7 +28,7 @@ async function main(): Promise<void> {
   const siteId = args[0];
   const awsProfile = args[1] || process.env.AWS_PROFILE;
   const awsRegion = process.env.AWS_REGION || 'us-east-1';
-  const bucketName = `${siteId}-terraform-state`;
+  const bucketName = `browse-dot-show-${siteId}-tf-state`;
 
   try {
     logProgress(`🚀 Bootstrapping Terraform state bucket for site: ${siteId}`);

--- a/scripts/deploy/site-destroy.ts
+++ b/scripts/deploy/site-destroy.ts
@@ -81,7 +81,7 @@ async function runTerraformDestroy(siteId: string, env: string): Promise<void> {
   try {
     // Bootstrap terraform state bucket if needed (ensures backend exists)
     printInfo('Ensuring Terraform state bucket exists...');
-    printInfo(`Expected bucket name: ${siteId}-terraform-state`);
+    printInfo(`Expected bucket name: browse-dot-show-${siteId}-tf-state`);
     await execCommandOrThrow('tsx', ['../../scripts/deploy/bootstrap-site-state.ts', siteId, process.env.AWS_PROFILE || '']);
     printSuccess('✅ Terraform state bucket bootstrap completed');
 


### PR DESCRIPTION
The script to create the Terraform state bucket does not use the same name format as at https://github.com/jackkoppa/browse-dot-show/blob/c58c109638c9617e381840d6d912afdd4822ec00/scripts/site-creator/step-executors.ts#L614 and https://github.com/jackkoppa/browse-dot-show/blob/c58c109638c9617e381840d6d912afdd4822ec00/scripts/site-creator/step-executors.ts#L721 so therefore the deploy fails

See log below:-

✅ ✅ Terraform state infrastructure created successfully!
ℹ️  Verifying Terraform state setup...
🔧 Executing: aws s3api head-bucket --bucket browse-dot-show-iwltr-tf-state --profile iwltr-deploy
❌ Command failed with exit code 254
   stderr:
An error occurred (404) when calling the HeadBucket operation: Not Found

❌ ❌ Terraform state verification failed: State bucket verification failed
ℹ️  The bootstrap may have partially completed. You can try running this step again.

